### PR TITLE
bug: fix the fc_norm layer weight and bias were not saved.

### DIFF
--- a/models_vit.py
+++ b/models_vit.py
@@ -22,6 +22,9 @@ class VisionTransformer(timm.models.vision_transformer.VisionTransformer):
             norm_layer = kwargs['norm_layer']
             embed_dim = kwargs['embed_dim']
             self.fc_norm = norm_layer(embed_dim)
+            
+            # manually register fc_norm to the model
+            self.add_module('fc_norm', self.fc_norm)
 
             del self.norm  # remove the original norm
 


### PR DESCRIPTION
When `args.global_pool == True`, the model do not register the fc_norm layer to the model, which make the fc_norm layer weight and bias will not be saved to `model.state_dict()` and make the saved checkpoint incomplete.